### PR TITLE
Use minetest.conf for settings

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,22 +1,26 @@
 
-travelnet.MAX_STATIONS_PER_NETWORK = 24;
+-- maximum travelnet stations per network
+travelnet.MAX_STATIONS_PER_NETWORK = tonumber(minetest.settings:get("travelnet.MAX_STATIONS_PER_NETWORK")) or 24;
 
 -- set this to true if you want a simulated beam effect
-travelnet.travelnet_effect_enabled = false;
+travelnet.travelnet_effect_enabled = minetest.settings:get_bool("travelnet.travelnet_effect_enabled") or false;
+
 -- set this to true if you want a sound to be played when the travelnet is used
-travelnet.travelnet_sound_enabled  = false;
+travelnet.travelnet_sound_enabled  = minetest.settings:get_bool("travelnet.travelnet_sound_enabled") or true;
 
 -- if you set this to false, travelnets cannot be created
 -- (this may be useful if you want nothing but the elevators on your server)
-travelnet.travelnet_enabled        = true;
+travelnet.travelnet_enabled        = minetest.settings:get_bool("travelnet.travelnet_enabled") or true;
+
 -- if you set travelnet.elevator_enabled to false, you will not be able to
 -- craft, place or use elevators
-travelnet.elevator_enabled         = true;
+travelnet.elevator_enabled         = minetest.settings:get_bool("travelnet.elevator_enabled") or true;
+
 -- if you set this to false, doors will be disabled
-travelnet.doors_enabled            = true;
+travelnet.doors_enabled            = minetest.settings:get_bool("travelnet.doors_enabled") or true;
 
 -- starts an abm which re-adds travelnet stations to networks in case the savefile got lost
-travelnet.abm_enabled              = false;
+travelnet.abm_enabled              = minetest.settings:get_bool("travelnet.abm_enabled") or false;
 
 -- change these if you want other receipes for travelnet or elevator
 travelnet.travelnet_recipe = {
@@ -120,4 +124,3 @@ travelnet.allow_travel = function( player_name, owner_name, network_name, statio
    return true;
 end
 
-travelnet.travelnet_sound_enabled = true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,7 @@
+travelnet.MAX_STATIONS_PER_NETWORK (Maximum travelnet stations per network) float 24
+travelnet.travelnet_effect_enabled (Travelnet visual beam effect) bool false
+travelnet.travelnet_sound_enabled (Travelnet sound effect) bool true
+travelnet.travelnet_enabled (Allow travelnets) bool true
+travelnet.elevator_enabled (Allow travelnet elevators) bool true
+travelnet.doors_enabled (Travelnet elevator doors) bool true
+travelnet.abm_enabled (Reconnect travelnets automatically via ABM) bool false


### PR DESCRIPTION
Now config.lua uses minetest.conf settings for variables that would normally be configurable, instead of containing only hard-coded settings. The settingtypes.txt file included with this pull request describes the settings following Minetest standards.